### PR TITLE
Add WAIT step type

### DIFF
--- a/rpa/workflow.py
+++ b/rpa/workflow.py
@@ -5,6 +5,44 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+class StepType(Enum):
+    CLICK = "click"
+    INPUT = "input"
+    SCREENSHOT = "screenshot"
+    FILE_COPY = "file_copy"
+    EXCEL_WRITE = "excel_write"
+    CONDITION = "if"
+    LOOP = "loop"
+    WAIT = "wait"
+    NOTIFY = "notify"
+
+
+@dataclass
+class Step:
+    step_type: Enum
+    payload: dict | None = None
+
+
+def execute_step(step: Step):
+    """Execute a single automation step."""
+    if step.step_type == StepType.CLICK:
+        logger.info("Executing click step")
+    elif step.step_type == StepType.INPUT:
+        logger.info("Executing input step")
+    elif step.step_type == StepType.SCREENSHOT:
+        logger.info("Executing screenshot step")
+    elif step.step_type == StepType.FILE_COPY:
+        logger.info("Executing file copy step")
+    elif step.step_type == StepType.EXCEL_WRITE:
+        logger.info("Executing excel write step")
+    elif step.step_type == StepType.CONDITION:
+        logger.info("Executing conditional step")
+    elif step.step_type == StepType.LOOP:
+        logger.info("Executing loop step")
+    elif step.step_type == StepType.WAIT:
+        logger.info("Executing wait step")
+    elif step.step_type == StepType.NOTIFY:
+        logger.info("Executing notify step")
     else:
         logger.error("Unknown StepType: %s", step.step_type)
         raise ValueError(f"Unknown StepType: {step.step_type}")

--- a/rpa/workflow.py
+++ b/rpa/workflow.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from dataclasses import dataclass
 import logging
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +41,12 @@ def execute_step(step: Step):
     elif step.step_type == StepType.LOOP:
         logger.info("Executing loop step")
     elif step.step_type == StepType.WAIT:
-        logger.info("Executing wait step")
+        seconds = 0
+        if step.payload is not None:
+            seconds = step.payload.get("seconds", 0)
+        logger.info("Executing wait step for %s seconds", seconds)
+        if seconds > 0:
+            time.sleep(seconds)
     elif step.step_type == StepType.NOTIFY:
         logger.info("Executing notify step")
     else:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -23,8 +23,17 @@ def test_condition_step_logs(caplog):
     assert "conditional step" in caplog.text
 
 
-def test_wait_step_logs(caplog):
-    step = Step(step_type=StepType.WAIT)
+def test_wait_step_logs_and_sleeps(monkeypatch, caplog):
+    recorded = {}
+
+    def fake_sleep(seconds):
+        recorded["seconds"] = seconds
+
+    monkeypatch.setattr("rpa.workflow.time.sleep", fake_sleep)
+
+    step = Step(step_type=StepType.WAIT, payload={"seconds": 2})
     with caplog.at_level(logging.INFO):
         execute_step(step)
-    assert "wait step" in caplog.text
+
+    assert recorded.get("seconds") == 2
+    assert "wait step for 2 seconds" in caplog.text

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,7 +1,6 @@
 import logging
 import pytest
 
-
 from rpa.workflow import Step, StepType, execute_step
 
 
@@ -17,11 +16,15 @@ def test_execute_step_unknown_type_logs_error(caplog):
     assert "Unknown StepType" in caplog.text
 
 
-
+def test_condition_step_logs(caplog):
+    step = Step(step_type=StepType.CONDITION, payload={"condition": True})
     with caplog.at_level(logging.INFO):
-        run_workflow(str(wf_file))
+        execute_step(step)
+    assert "conditional step" in caplog.text
 
-    text = caplog.text
-    assert "Executing click step" in text
-    assert "Condition evaluated" in text
 
+def test_wait_step_logs(caplog):
+    step = Step(step_type=StepType.WAIT)
+    with caplog.at_level(logging.INFO):
+        execute_step(step)
+    assert "wait step" in caplog.text


### PR DESCRIPTION
## Summary
- restore workflow module and tests
- add `WAIT` step type and example test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68426d3991d48327a306dd7f43380d1f