### PR TITLE
Replace union syntax with Optional

### DIFF
--- a/rpa/__main__.py
+++ b/rpa/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+from typing import Optional
 
 from .workflow import Step, StepType, execute_step
 
@@ -26,7 +27,7 @@ def run_workflow(file_path: str) -> None:
         execute_step(step)
 
 
-def main(argv: list[str] | None = None) -> None:
+def main(argv: Optional[list[str]] = None) -> None:
     parser = argparse.ArgumentParser(description="Run RPA workflow")
     parser.add_argument("workflow", nargs="?", default="workflow.json",
                         help="Path to workflow JSON file")

--- a/rpa/workflow.py
+++ b/rpa/workflow.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from dataclasses import dataclass
+from typing import Optional
 import logging
 import time
 
@@ -21,7 +22,7 @@ class StepType(Enum):
 @dataclass
 class Step:
     step_type: Enum
-    payload: dict | None = None
+    payload: Optional[dict] = None
 
 
 def execute_step(step: Step):

--- a/rpa_gui.py
+++ b/rpa_gui.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 
 from PySide6 import QtWidgets, QtCore
 
@@ -25,7 +25,7 @@ class QTextEditLogger(logging.Handler):
 class StepDialog(QtWidgets.QDialog):
     """Dialog to create or edit a step."""
 
-    def __init__(self, parent: QtWidgets.QWidget | None = None):
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
         super().__init__(parent)
         self.setWindowTitle("Add Step")
         self.layout = QtWidgets.QFormLayout(self)


### PR DESCRIPTION
## Summary
- ensure Python 3.8 compatibility by replacing PEP604 union syntax with `Optional`
- update typing imports accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843e5ee23308327bb0f51bb8bfcba88