### PR TITLE
Support wait step in core modules

### DIFF
--- a/rpa.py
+++ b/rpa.py
@@ -3,6 +3,7 @@
 import json
 import os
 import logging
+import time
 from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,8 @@ class Step:
             self._if()
         elif self.action == "for":
             self._for()
+        elif self.action == "wait":
+            self._wait()
         elif self.action == "notify":
             self._notify()
         else:
@@ -108,6 +111,12 @@ class Step:
         for _ in range(count):
             for step in steps:
                 step.execute()
+
+    def _wait(self) -> None:
+        seconds = int(self.params.get("seconds", 0))
+        logger.info("Waiting for %s seconds", seconds)
+        if seconds > 0:
+            time.sleep(seconds)
 
     def _notify(self) -> None:
         message = self.params.get("message", "")

--- a/rpa/__main__.py
+++ b/rpa/__main__.py
@@ -1,13 +1,14 @@
 import argparse
 import json
 import logging
+from typing import Optional, List
 
 from .workflow import Step, StepType, execute_step
 
 logger = logging.getLogger(__name__)
 
 
-def load_steps(file_path: str) -> list[Step]:
+def load_steps(file_path: str) -> List[Step]:
     """Load workflow steps from a JSON file."""
     with open(file_path, "r", encoding="utf-8") as f:
         data = json.load(f)
@@ -26,7 +27,7 @@ def run_workflow(file_path: str) -> None:
         execute_step(step)
 
 
-def main(argv: list[str] | None = None) -> None:
+def main(argv: Optional[List[str]] = None) -> None:
     parser = argparse.ArgumentParser(description="Run RPA workflow")
     parser.add_argument("workflow", nargs="?", default="workflow.json",
                         help="Path to workflow JSON file")

--- a/rpa/workflow.py
+++ b/rpa/workflow.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from dataclasses import dataclass
+from typing import Optional
 import logging
 import time
 
@@ -21,7 +22,7 @@ class StepType(Enum):
 @dataclass
 class Step:
     step_type: Enum
-    payload: dict | None = None
+    payload: Optional[dict] = None
 
 
 def execute_step(step: Step):

--- a/rpa10021/manager.py
+++ b/rpa10021/manager.py
@@ -1,4 +1,5 @@
 import pyautogui
+import time
 
 class StepManager:
     def __init__(self, workflow=None):
@@ -13,3 +14,8 @@ class StepManager:
             elif action == 'typewrite':
                 text = step.get('text', '')
                 pyautogui.typewrite(text)
+            elif action == 'wait':
+                seconds = step.get('seconds', 0)
+                if seconds:
+                    time.sleep(seconds)
+

--- a/rpa_gui.py
+++ b/rpa_gui.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 
 from PySide6 import QtWidgets, QtCore
 
@@ -25,7 +25,7 @@ class QTextEditLogger(logging.Handler):
 class StepDialog(QtWidgets.QDialog):
     """Dialog to create or edit a step."""
 
-    def __init__(self, parent: QtWidgets.QWidget | None = None):
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
         super().__init__(parent)
         self.setWindowTitle("Add Step")
         self.layout = QtWidgets.QFormLayout(self)
@@ -40,6 +40,7 @@ class StepDialog(QtWidgets.QDialog):
                 "excel_write",
                 "if",
                 "for",
+                "wait",
                 "notify",
             ]
         )
@@ -82,6 +83,8 @@ class StepDialog(QtWidgets.QDialog):
             self.param_edits["condition"] = QtWidgets.QLineEdit()
         elif action == "for":
             self.param_edits["count"] = QtWidgets.QLineEdit("1")
+        elif action == "wait":
+            self.param_edits["seconds"] = QtWidgets.QLineEdit("1")
         elif action == "notify":
             self.param_edits["message"] = QtWidgets.QLineEdit()
             self.param_edits["email"] = QtWidgets.QLineEdit()


### PR DESCRIPTION
## Summary
- implement `wait` action in `rpa.py` engine
- add `wait` option to GUI dialog
- handle wait steps in simple manager
- use `List` typing for CLI to keep Python 3.8 compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843e5ee23308327bb0f51bb8bfcba88