### PR TITLE
Implement web element capture via WebSocket

### DIFF
--- a/rpa/__init__.py
+++ b/rpa/__init__.py
@@ -1,5 +1,6 @@
 from .workflow import StepType, Step, execute_step
 from .__main__ import run_workflow
+from .web_capture import WebElementServer
 
-__all__ = ["StepType", "Step", "execute_step", "run_workflow"]
+__all__ = ["StepType", "Step", "execute_step", "run_workflow", "WebElementServer"]
 

--- a/rpa/web_capture.py
+++ b/rpa/web_capture.py
@@ -1,0 +1,54 @@
+import asyncio
+import json
+import threading
+
+try:
+    import websockets  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    websockets = None
+
+
+class WebElementServer:
+    """Simple WebSocket server to receive captured web element info."""
+
+    def __init__(self, host: str = "localhost", port: int = 8765) -> None:
+        self.host = host
+        self.port = port
+        self.elements = []
+        self.loop: asyncio.AbstractEventLoop | None = None
+        self.server = None
+        self.thread: threading.Thread | None = None
+
+    async def _handler(self, websocket):  # type: ignore[no-untyped-def]
+        async for message in websocket:
+            try:
+                data = json.loads(message)
+            except json.JSONDecodeError:
+                continue
+            self.elements.append(data)
+
+    def start(self) -> None:
+        """Start the WebSocket server in a background thread."""
+        if not websockets:
+            raise RuntimeError("websockets library not installed")
+        self.loop = asyncio.new_event_loop()
+        self.server = self.loop.run_until_complete(
+            websockets.serve(self._handler, self.host, self.port)
+        )
+        self.thread = threading.Thread(target=self.loop.run_forever, daemon=True)
+        self.thread.start()
+
+    def stop(self) -> None:
+        """Stop the WebSocket server."""
+        if self.server and self.loop:
+            self.loop.call_soon_threadsafe(self.server.close)
+            self.loop.call_soon_threadsafe(self.loop.stop)
+            if self.thread:
+                self.thread.join()
+        self.server = None
+        self.loop = None
+        self.thread = None
+
+    def get_elements(self):
+        """Return list of captured elements."""
+        return list(self.elements)


### PR DESCRIPTION
## Summary
- add `WebElementServer` for capturing CSS/XPath over WebSocket
- expose `WebElementServer` from package
- extend GUI with `Capture Elements` dialog to open URLs and save captured elements

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68469f29256c8327a0505024a341759b