### PR TITLE
Implement element retrieval helpers

### DIFF
--- a/rpa/__init__.py
+++ b/rpa/__init__.py
@@ -1,5 +1,20 @@
 from .workflow import StepType, Step, execute_step
 from .__main__ import run_workflow
+from .elements import (
+    fetch_web_element,
+    get_desktop_element,
+    record_click_position,
+    match_image,
+)
 
-__all__ = ["StepType", "Step", "execute_step", "run_workflow"]
+__all__ = [
+    "StepType",
+    "Step",
+    "execute_step",
+    "run_workflow",
+    "fetch_web_element",
+    "get_desktop_element",
+    "record_click_position",
+    "match_image",
+]
 

--- a/rpa/elements.py
+++ b/rpa/elements.py
@@ -1,0 +1,92 @@
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    import websockets
+    import asyncio
+except Exception:  # pragma: no cover - optional dependency
+    websockets = None
+    asyncio = None
+
+try:
+    import uiautomation as auto
+except Exception:  # pragma: no cover - optional dependency
+    auto = None
+
+try:
+    import pyautogui
+except Exception:  # pragma: no cover - optional dependency
+    pyautogui = None
+
+try:
+    import cv2
+    import numpy as np
+except Exception:  # pragma: no cover - optional dependency
+    cv2 = None
+    np = None
+
+
+def fetch_web_element(selector: str, ws_url: str = "ws://localhost:8765") -> dict:
+    """Fetch web element information via WebSocket.
+
+    Parameters
+    ----------
+    selector: str
+        CSS selector or XPath to query.
+    ws_url: str
+        WebSocket URL of the running browser extension.
+
+    Returns
+    -------
+    dict
+        Element information provided by the extension.
+    """
+    if not websockets or not asyncio:
+        raise RuntimeError("websockets library is required for fetch_web_element")
+
+    async def _fetch() -> dict:
+        async with websockets.connect(ws_url) as ws:
+            await ws.send(json.dumps({"selector": selector}))
+            data = await ws.recv()
+            return json.loads(data)
+
+    return asyncio.get_event_loop().run_until_complete(_fetch())
+
+
+def get_desktop_element(**kwargs) -> dict:
+    """Retrieve a Windows desktop element using uiautomation.
+
+    Parameters can be any keyword arguments accepted by ``uiautomation.Control``.
+    """
+    if not auto:
+        raise RuntimeError("uiautomation library is required for get_desktop_element")
+    ctrl = auto.Control(**kwargs)
+    rect = ctrl.BoundingRectangle
+    return {
+        "left": rect.left,
+        "top": rect.top,
+        "right": rect.right,
+        "bottom": rect.bottom,
+    }
+
+
+def record_click_position() -> tuple:
+    """Return the current mouse cursor position."""
+    if not pyautogui:
+        raise RuntimeError("pyautogui is required for record_click_position")
+    return pyautogui.position()
+
+
+def match_image(template_path: str, image_path: str) -> dict:
+    """Find ``template_path`` inside ``image_path`` using OpenCV."""
+    if not cv2 or not np:
+        raise RuntimeError("opencv-python is required for match_image")
+    template = cv2.imread(template_path, 0)
+    image = cv2.imread(image_path, 0)
+    if template is None or image is None:
+        raise ValueError("Unable to read image files")
+    res = cv2.matchTemplate(image, template, cv2.TM_CCOEFF_NORMED)
+    _min_val, max_val, _min_loc, max_loc = cv2.minMaxLoc(res)
+    return {"x": int(max_loc[0]), "y": int(max_loc[1]), "score": float(max_val)}

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from rpa import elements
+
+
+def test_fetch_web_element_requires_websockets(monkeypatch):
+    monkeypatch.setattr(elements, "websockets", None)
+    with pytest.raises(RuntimeError):
+        elements.fetch_web_element("div")
+
+
+def test_get_desktop_element_requires_uiautomation(monkeypatch):
+    monkeypatch.setattr(elements, "auto", None)
+    with pytest.raises(RuntimeError):
+        elements.get_desktop_element(AutomationId="test")
+
+
+def test_record_click_position_requires_pyautogui(monkeypatch):
+    monkeypatch.setattr(elements, "pyautogui", None)
+    with pytest.raises(RuntimeError):
+        elements.record_click_position()
+
+
+def test_match_image_requires_opencv(monkeypatch):
+    monkeypatch.setattr(elements, "cv2", None)
+    monkeypatch.setattr(elements, "np", None)
+    with pytest.raises(RuntimeError):
+        elements.match_image("a.png", "b.png")


### PR DESCRIPTION
## Summary
- add helper module for fetching web and desktop elements
- expose helper functions in package init
- test that functions handle missing dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68477edb748c8327aed252758d57e638